### PR TITLE
Adjust DispatcherTimer interval for performance

### DIFF
--- a/Dialogs/ChannelControl.xaml.cs
+++ b/Dialogs/ChannelControl.xaml.cs
@@ -132,7 +132,7 @@ namespace DeejNG.Dialogs
             // Replace CompositionTarget.Rendering with controlled timer for better performance
             _meterUpdateTimer = new DispatcherTimer
             {
-                Interval = TimeSpan.FromMilliseconds(8) // Very high FPS for ultra-smooth visuals
+                Interval = TimeSpan.FromMilliseconds(16) // Very high FPS for ultra-smooth visuals
             };
             _meterUpdateTimer.Tick += MeterUpdateTimer_Tick;
             _meterUpdateTimer.Start();


### PR DESCRIPTION
Modified the `DispatcherTimer` interval in `ChannelControl.xaml.cs` from 8 milliseconds to 16 milliseconds. This change aims to maintain high frame rates while potentially improving performance by reducing the frequency of timer ticks.