### PR TITLE
Adjust DispatcherTimer interval for performance

### DIFF
--- a/Dialogs/ChannelControl.xaml.cs
+++ b/Dialogs/ChannelControl.xaml.cs
@@ -132,7 +132,7 @@ namespace DeejNG.Dialogs
             // Replace CompositionTarget.Rendering with controlled timer for better performance
             _meterUpdateTimer = new DispatcherTimer
             {
-                Interval = TimeSpan.FromMilliseconds(16) // Very high FPS for ultra-smooth visuals
+                Interval = TimeSpan.FromMilliseconds(25) // Very high FPS for ultra-smooth visuals
             };
             _meterUpdateTimer.Tick += MeterUpdateTimer_Tick;
             _meterUpdateTimer.Start();


### PR DESCRIPTION
Modified the `DispatcherTimer` interval in `ChannelControl.xaml.cs` from 16 milliseconds to 25 milliseconds. This change aims to maintain high frame rates while potentially reducing system load, improving overall performance and efficiency.