### PR TITLE
Add support for Output Devices

### DIFF
--- a/Dialogs/ChannelControl.xaml.cs
+++ b/Dialogs/ChannelControl.xaml.cs
@@ -191,7 +191,7 @@ namespace DeejNG.Dialogs
         public void HandleSessionDisconnected()
         {
             // If we were controlling this session exclusively
-            if (_audioTargets.Count == 1 && !_audioTargets[0].IsInputDevice)
+            if (_audioTargets.Count == 1 && !_audioTargets[0].IsInputDevice && !_audioTargets[0].IsOutputDevice)
             {
                 string target = _audioTargets[0].Name;
                 Debug.WriteLine($"[Session] Session disconnected for {target}");
@@ -215,7 +215,7 @@ namespace DeejNG.Dialogs
         public void HandleSessionExpired()
         {
             // Similar to disconnected, but may want different visual treatment
-            if (_audioTargets.Count == 1 && !_audioTargets[0].IsInputDevice)
+            if (_audioTargets.Count == 1 && !_audioTargets[0].IsInputDevice && !_audioTargets[0].IsOutputDevice)
             {
                 string target = _audioTargets[0].Name;
                 Debug.WriteLine($"[Session] Session expired for {target}");
@@ -585,7 +585,7 @@ namespace DeejNG.Dialogs
 
                 // Set tooltip to show all targets
                 TargetTextBox.ToolTip = string.Join("\n", _audioTargets.Select(t =>
-                    $"{t.Name} {(t.IsInputDevice ? "(Input)" : "")}"));
+                    $"{t.Name} {(t.IsInputDevice ? "(Input)" : (t.IsOutputDevice ? "(Output)" : ""))}"));
             }
 
             // Reset foreground color (in case it was previously set to indicate disconnection)

--- a/Dialogs/MultiTargetPickerDialog.xaml
+++ b/Dialogs/MultiTargetPickerDialog.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Select Applications" Height="500" Width="500"
+        Title="Select Applications" Height="600" Width="800"
         TextElement.Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
         Background="{DynamicResource MaterialDesign.Brush.Background}"
         TextElement.FontWeight="Regular"
@@ -24,20 +24,22 @@
 
         <!-- Instruction -->
         <TextBlock Grid.Row="1" 
-                   Text="Note: You can select either output applications OR input devices, but not both. Applications already assigned to other sliders are marked and cannot be selected."
+                   Text="Note: You can select multiple items, but they must be in the same category. Applications already assigned to other sliders are marked and cannot be selected."
                    Style="{StaticResource MaterialDesignBody2TextBlock}"
                    TextWrapping="Wrap"
                    Margin="0,0,0,10"/>
+
 
         <!-- Session List with Checkboxes -->
         <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
             <!-- Available sessions -->
-            <GroupBox Header="Output Applications" Grid.Column="0" Margin="0,0,5,0" MinHeight="300">
+            <GroupBox Header="Applications" Grid.Column="0" Margin="0,0,5,0" MinHeight="300">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <ListBox x:Name="AvailableSessionsListBox" Margin="0,5">
                         <ListBox.ItemTemplate>
@@ -53,7 +55,7 @@
             </GroupBox>
 
             <!-- Input device selection -->
-            <GroupBox Header="Input Devices" Grid.Column="1" Width="200" MinHeight="300">
+            <GroupBox Header="Input Devices" Grid.Column="1" Margin="0,0,5,0" MinHeight="300">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <ListBox x:Name="InputDevicesListBox" Margin="0,5">
                         <ListBox.ItemTemplate>
@@ -67,7 +69,25 @@
                     </ListBox>
                 </ScrollViewer>
             </GroupBox>
+
+            <!-- Output device selection -->
+            <GroupBox Header="Output Devices" Grid.Column="2" MinHeight="300">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <ListBox x:Name="OutputDevicesListBox" Margin="0,5">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox Content="{Binding FriendlyName}" 
+                                          IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                          IsEnabled="{Binding IsEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                          Margin="0,2"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </ScrollViewer>
+            </GroupBox>
         </Grid>
+
+
 
         <!-- Action Buttons -->
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">

--- a/Models/AudioTarget.cs
+++ b/Models/AudioTarget.cs
@@ -10,6 +10,7 @@ namespace DeejNG.Models
     {
         public string Name { get; set; } = "";
         public bool IsInputDevice { get; set; } = false;
+        public bool IsOutputDevice { get; set; } = false;
 
         public override string ToString() => Name;
 
@@ -17,13 +18,14 @@ namespace DeejNG.Models
         {
             if (obj is AudioTarget other)
                 return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) &&
-                       IsInputDevice == other.IsInputDevice;
+                       IsInputDevice == other.IsInputDevice &&
+                       IsOutputDevice == other.IsOutputDevice;
             return false;
         }
 
         public override int GetHashCode()
         {
-            return (Name?.ToLowerInvariant()?.GetHashCode() ?? 0) ^ IsInputDevice.GetHashCode();
+            return (Name?.ToLowerInvariant()?.GetHashCode() ?? 0) ^ IsInputDevice.GetHashCode() ^ IsOutputDevice.GetHashCode();
         }
     }
 }


### PR DESCRIPTION
This pull request adds support to control specific output devices, similar to the original version of Deej.

This is useful for VoiceMeeter users, because just changing system volume alone has no effect on volume.

This could also be useful for other scenarios where multiple output devices are used.

<img width="775" height="579" alt="image" src="https://github.com/user-attachments/assets/d59e9af6-94c5-475c-9365-feb5cf8ebce1" />
