### PR TITLE
Enhance AudioService for multiple audio session caching

### DIFF
--- a/Classes/AudioService.cs
+++ b/Classes/AudioService.cs
@@ -13,16 +13,18 @@ namespace DeejNG.Services
         private readonly MMDeviceEnumerator _deviceEnumerator = new();
         private readonly object _cacheLock = new object();
         private readonly Dictionary<string, DateTime> _sessionAccessTimes = new Dictionary<string, DateTime>();
-        private readonly Dictionary<string, SessionInfo> _sessionCache = new Dictionary<string, SessionInfo>(StringComparer.OrdinalIgnoreCase);
+
+        // 🔥 KEY CHANGE: Cache multiple sessions per app instead of single session
+        private readonly Dictionary<string, List<SessionInfo>> _sessionCache = new Dictionary<string, List<SessionInfo>>(StringComparer.OrdinalIgnoreCase);
+
         private DateTime _lastRefresh = DateTime.MinValue;
-        private const int CACHE_REFRESH_SECONDS = 5; // Refresh cache every 5 seconds
+        private const int CACHE_REFRESH_SECONDS = 5;
         private DateTime _lastUnmappedVolumeCall = DateTime.MinValue;
         private float _lastUnmappedVolume = -1f;
         private bool _lastUnmappedMuted = false;
         private HashSet<string> _lastMappedApps = new();
-        private readonly HashSet<int> _systemProcessIds = new HashSet<int> { 0, 4, 8 }; // Known system process IDs
-        private const int MAX_SESSION_CACHE_SIZE = 15; // Reduced from unlimited
- 
+        private readonly HashSet<int> _systemProcessIds = new HashSet<int> { 0, 4, 8 };
+        private const int MAX_SESSION_CACHE_SIZE = 15;
 
         private class SessionInfo
         {
@@ -37,119 +39,6 @@ namespace DeejNG.Services
             RefreshSessionCache();
         }
 
-        public void ApplyMuteStateToTarget(string target, bool isMuted)
-        {
-            if (string.IsNullOrWhiteSpace(target)) return;
-
-            if (target.Equals("system", StringComparison.OrdinalIgnoreCase))
-            {
-                var dev = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                dev.AudioEndpointVolume.Mute = isMuted;
-                return;
-            }
-
-            // See if we need to refresh the cache
-            if ((DateTime.Now - _lastRefresh).TotalSeconds > CACHE_REFRESH_SECONDS)
-            {
-                RefreshSessionCache();
-            }
-
-            // Try to find the session in our cache
-            lock (_cacheLock)
-            {
-                if (_sessionCache.TryGetValue(target, out var sessionInfo))
-                {
-                    try
-                    {
-                        sessionInfo.Session.SimpleAudioVolume.Mute = isMuted;
-                        _sessionAccessTimes[target] = DateTime.Now;
-                        return;
-                    }
-                    catch (Exception ex)
-                    {
-                        // If we can't access the session, it may have been closed
-                        Debug.WriteLine($"[AudioService] Failed to mute {target}: {ex.Message}");
-                        _sessionCache.Remove(target);
-                    }
-                }
-            }
-
-            // If we didn't find it in the cache or had an error, try direct approach
-            try
-            {
-                var dev = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                var sessions = dev.AudioSessionManager.Sessions;
-
-                for (int i = 0; i < sessions.Count; i++)
-                {
-                    try
-                    {
-                        var session = sessions[i];
-
-                        // Skip if null
-                        if (session == null) continue;
-
-                        string sessionId = session.GetSessionIdentifier?.ToLower() ?? "";
-                        string instanceId = session.GetSessionInstanceIdentifier?.ToLower() ?? "";
-                        int processId = 0;
-
-                        try { processId = (int)session.GetProcessID; }
-                        catch { continue; } // Skip if we can't get process ID
-
-                        // Try to get the process name
-                        string processName = AudioUtilities.GetProcessNameSafely(processId);
-                        
-                        if (string.IsNullOrEmpty(processName))
-                        {
-                            // If we can't get the name, use the ID in the session ID
-                            processName = $"unknown_{processId}";
-                        }
-
-                        // Check if this session matches our target
-                        if (processName.Equals(target, StringComparison.OrdinalIgnoreCase) ||
-                            sessionId.Contains(target) ||
-                            instanceId.Contains(target))
-                        {
-                            session.SimpleAudioVolume.Mute = isMuted;
-
-                            // Add to cache
-                            lock (_cacheLock)
-                            {
-                                _sessionCache[target] = new SessionInfo
-                                {
-                                    Session = session,
-                                    ProcessName = processName,
-                                    ProcessId = processId,
-                                    LastSeen = DateTime.Now
-                                };
-                                _sessionAccessTimes[target] = DateTime.Now;
-                            }
-
-                            return;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Debug.WriteLine($"[AudioService] Error processing session {i}: {ex.Message}");
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[AudioService] Failed to apply mute state: {ex.Message}");
-            }
-        }
-
-        public void ApplyMuteStateToMultipleTargets(List<string> targets, bool isMuted)
-        {
-            if (targets == null || !targets.Any()) return;
-
-            foreach (var target in targets)
-            {
-                ApplyMuteStateToTarget(target, isMuted);
-            }
-        }
-
         public void ApplyVolumeToTarget(string executable, float level, bool isMuted = false)
         {
             level = Math.Clamp(level, 0.0f, 1.0f);
@@ -161,7 +50,6 @@ namespace DeejNG.Services
                 {
                     var device = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
                     device.AudioEndpointVolume.Mute = isMuted;
-
                     if (!isMuted)
                     {
                         device.AudioEndpointVolume.MasterVolumeLevelScalar = level;
@@ -174,86 +62,47 @@ namespace DeejNG.Services
                 return;
             }
 
-            // Normalize the executable name
             string cleanedExecutable = Path.GetFileNameWithoutExtension(executable).ToLowerInvariant();
 
-            // See if we need to refresh the cache
+            // Use cache if fresh, otherwise enumerate directly (like PR does)
             if ((DateTime.Now - _lastRefresh).TotalSeconds > CACHE_REFRESH_SECONDS)
             {
                 RefreshSessionCache();
             }
 
-            // Try to find the session in our cache
-            lock (_cacheLock)
-            {
-                if (_sessionCache.TryGetValue(cleanedExecutable, out var sessionInfo))
-                {
-                    try
-                    {
-                        sessionInfo.Session.SimpleAudioVolume.Mute = isMuted;
-
-                        if (!isMuted)
-                        {
-                            sessionInfo.Session.SimpleAudioVolume.Volume = level;
-                        }
-
-                        _sessionAccessTimes[cleanedExecutable] = DateTime.Now;
-                        return;
-                    }
-                    catch (Exception ex)
-                    {
-                        // If we can't access the session, it may have been closed
-                        Debug.WriteLine($"[AudioService] Failed to set volume for {cleanedExecutable}: {ex.Message}");
-                        _sessionCache.Remove(cleanedExecutable);
-                    }
-                }
-            }
-
-            // If we didn't find it in the cache or had an error, try direct approach
+            // Always enumerate all sessions to find ALL matches (PR behavior)
+            // But use cached process names for performance
             try
             {
                 var sessions = _deviceEnumerator
                     .GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia)
                     .AudioSessionManager.Sessions;
 
+                int sessionCount = 0;
+
                 for (int i = 0; i < sessions.Count; i++)
                 {
-                    var session = sessions[i];
                     try
                     {
+                        var session = sessions[i];
+                        if (session == null) continue;
+
                         int processId = (int)session.GetProcessID;
                         string procName = AudioUtilities.GetProcessNameSafely(processId);
-                        
-                        if (string.IsNullOrEmpty(procName))
-                        {
-                            continue; // Skip if we can't get the process name
-                        }
+
+                        if (string.IsNullOrEmpty(procName)) continue;
 
                         string cleanedProcName = Path.GetFileNameWithoutExtension(procName).ToLowerInvariant();
 
                         if (cleanedProcName.Equals(cleanedExecutable, StringComparison.OrdinalIgnoreCase))
                         {
                             session.SimpleAudioVolume.Mute = isMuted;
-
                             if (!isMuted)
                             {
                                 session.SimpleAudioVolume.Volume = level;
                             }
-
-                            // Add to cache
-                            lock (_cacheLock)
-                            {
-                                _sessionCache[cleanedExecutable] = new SessionInfo
-                                {
-                                    Session = session,
-                                    ProcessName = cleanedProcName,
-                                    ProcessId = processId,
-                                    LastSeen = DateTime.Now
-                                };
-                                _sessionAccessTimes[cleanedExecutable] = DateTime.Now;
-                            }
-
-                            return;
+                            sessionCount++;
+                            // DON'T BREAK - continue to find more sessions (PR's key change)
                         }
                     }
                     catch (Exception ex)
@@ -262,199 +111,130 @@ namespace DeejNG.Services
                     }
                 }
 
-                // If we get here, we didn't find the session - log it
-                Debug.WriteLine($"[AudioService] Could not find session for {cleanedExecutable}");
+                if (sessionCount == 0)
+                {
+                    Debug.WriteLine($"[AudioService] Could not find any session for {cleanedExecutable}");
+                }
+                else
+                {
+                    Debug.WriteLine($"[AudioService] Applied volume to {sessionCount} sessions for {cleanedExecutable}");
+                }
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"[AudioService] Failed to apply volume: {ex.Message}");
             }
         }
-        // Add this method to your AudioService class
-        public void ApplyVolumeToUnmappedApplications(float level, bool isMuted, HashSet<string> mappedApplications)
+        public void ApplyMuteStateToTarget(string target, bool isMuted)
         {
-            level = Math.Clamp(level, 0.0f, 1.0f);
+            if (string.IsNullOrWhiteSpace(target)) return;
 
-            // THROTTLING: Only process if enough time has passed or values changed significantly
-            var now = DateTime.Now;
-            var timeSinceLastCall = (now - _lastUnmappedVolumeCall).TotalMilliseconds;
-            var volumeChanged = Math.Abs(_lastUnmappedVolume - level) > 0.05f; // 2% change threshold (more sensitive)
-            var muteChanged = _lastUnmappedMuted != isMuted;
-            var appsChanged = !_lastMappedApps.SetEquals(mappedApplications);
-
-            if (timeSinceLastCall < 100 && !volumeChanged && !muteChanged && !appsChanged) // 250ms throttle
+            if (target.Equals("system", StringComparison.OrdinalIgnoreCase))
             {
-                return; // Skip this call to reduce processing
+                var dev = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                dev.AudioEndpointVolume.Mute = isMuted;
+                return;
             }
 
-            _lastUnmappedVolumeCall = now;
-            _lastUnmappedVolume = level;
-            _lastUnmappedMuted = isMuted;
-            _lastMappedApps = new HashSet<string>(mappedApplications);
+            // 🚀 SAME HYBRID APPROACH for muting
+            bool sessionFound = false;
 
-            try
+            // Try cache first
+            if ((DateTime.Now - _lastRefresh).TotalSeconds <= CACHE_REFRESH_SECONDS)
             {
-                var device = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                var sessions = device.AudioSessionManager.Sessions;
-
-                int processedCount = 0;
-                int skippedCount = 0;
-
-                for (int i = 0; i < sessions.Count; i++)
+                lock (_cacheLock)
                 {
-                    try
+                    if (_sessionCache.TryGetValue(target, out var cachedSessions))
                     {
-                        var session = sessions[i];
-                        if (session == null)
-                        {
-                            skippedCount++;
-                            continue;
-                        }
+                        var validSessions = new List<SessionInfo>();
 
-                        // Get process ID first
-                        int processId;
-                        try
+                        foreach (var sessionInfo in cachedSessions)
                         {
-                            processId = (int)session.GetProcessID;
-                        }
-                        catch
-                        {
-                            skippedCount++;
-                            continue;
-                        }
-
-                        // Skip system sessions immediately - these can't be controlled and cause Win32Exception
-                        if (_systemProcessIds.Contains(processId) || processId < 100)
-                        {
-                            skippedCount++;
-                            continue;
-                        }
-
-                        // Get process name with caching
-                        string processName = AudioUtilities.GetProcessNameSafely(processId);
-
-                        if (string.IsNullOrEmpty(processName))
-                        {
-                            skippedCount++;
-                            continue;
-                        }
-
-                        // Skip if this application is already mapped to a slider
-                        if (mappedApplications.Contains(processName))
-                        {
-                            skippedCount++;
-                            continue;
-                        }
-
-                        // Apply volume to this unmapped session
-                        try
-                        {
-                            session.SimpleAudioVolume.Mute = isMuted;
-                            if (!isMuted)
+                            try
                             {
-                                session.SimpleAudioVolume.Volume = level;
+                                sessionInfo.Session.SimpleAudioVolume.Mute = isMuted;
+                                validSessions.Add(sessionInfo);
+                                sessionFound = true;
                             }
-                            processedCount++;
+                            catch (Exception ex)
+                            {
+                                Debug.WriteLine($"[AudioService] Failed to mute cached session for {target}: {ex.Message}");
+                            }
                         }
-                        catch (Exception ex)
+
+                        if (validSessions.Count > 0)
                         {
-                            Debug.WriteLine($"[Unmapped] Failed to apply volume to {processName}: {ex.GetType().Name}");
-                            skippedCount++;
+                            _sessionCache[target] = validSessions;
+                            _sessionAccessTimes[target] = DateTime.Now;
                         }
-                    }
-                    catch
-                    {
-                        skippedCount++;
+                        else
+                        {
+                            _sessionCache.Remove(target);
+                            _sessionAccessTimes.Remove(target);
+                        }
+
+                        if (sessionFound) return;
                     }
                 }
-
-                // Only log significant changes or errors
-              
             }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[Unmapped] Failed to apply volume: {ex.GetType().Name}");
-            }
-        }
-        // Replace your ApplyMuteStateToUnmappedApplications method in AudioService.cs with this safer version:
 
-        public void ApplyMuteStateToUnmappedApplications(bool isMuted, HashSet<string> mappedApplications)
-        {
+            // Fallback to direct enumeration if cache miss or invalid
             try
             {
-                var device = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                var sessions = device.AudioSessionManager.Sessions;
-
-                int processedCount = 0;
-                int skippedCount = 0;
+                var dev = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var sessions = dev.AudioSessionManager.Sessions;
+                var foundSessions = new List<SessionInfo>();
 
                 for (int i = 0; i < sessions.Count; i++)
                 {
                     try
                     {
                         var session = sessions[i];
-                        if (session == null)
-                        {
-                            skippedCount++;
-                            continue;
-                        }
+                        if (session == null) continue;
 
-                        int processId;
-                        try
-                        {
-                            processId = (int)session.GetProcessID;
-                        }
-                        catch
-                        {
-                            skippedCount++;
-                            continue;
-                        }
-
-                        // Skip system sessions that cause Win32Exception
-                        if (_systemProcessIds.Contains(processId) || processId < 100)
-                        {
-                            skippedCount++;
-                            continue;
-                        }
-
+                        int processId = (int)session.GetProcessID;
                         string processName = AudioUtilities.GetProcessNameSafely(processId);
 
                         if (string.IsNullOrEmpty(processName))
                         {
-                            skippedCount++;
-                            continue;
+                            processName = $"unknown_{processId}";
                         }
 
-                        // Skip if this application is already mapped
-                        if (mappedApplications.Contains(processName))
-                        {
-                            skippedCount++;
-                            continue;
-                        }
-
-                        try
+                        if (processName.Equals(target, StringComparison.OrdinalIgnoreCase))
                         {
                             session.SimpleAudioVolume.Mute = isMuted;
-                            processedCount++;
-                        }
-                        catch
-                        {
-                            skippedCount++;
+                            foundSessions.Add(new SessionInfo
+                            {
+                                Session = session,
+                                ProcessName = processName,
+                                ProcessId = processId,
+                                LastSeen = DateTime.Now
+                            });
+                            sessionFound = true;
                         }
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        skippedCount++;
+                        Debug.WriteLine($"[AudioService] Error processing session {i}: {ex.Message}");
                     }
                 }
 
-                Debug.WriteLine($"[Unmapped] Mute {isMuted} applied to {processedCount} apps");
+                // Update cache with found sessions
+                if (foundSessions.Count > 0)
+                {
+                    lock (_cacheLock)
+                    {
+                        _sessionCache[target] = foundSessions;
+                        _sessionAccessTimes[target] = DateTime.Now;
+                    }
+                }
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[Unmapped] Failed to mute unmapped applications: {ex.GetType().Name}");
+                Debug.WriteLine($"[AudioService] Failed to apply mute state: {ex.Message}");
             }
         }
+
         private void RefreshSessionCache()
         {
             try
@@ -464,11 +244,12 @@ namespace DeejNG.Services
                     .AudioSessionManager.Sessions;
 
                 var currentTime = DateTime.Now;
-                var processedSessions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 var currentProcessIds = new HashSet<int>();
 
-                // Limit the number of sessions we process
-                int maxSessionsToProcess = Math.Min(sessions.Count, 20); // Don't process more than 20 sessions
+                // 🔥 NEW: Group sessions by process name to handle multiple sessions per app
+                var sessionsByApp = new Dictionary<string, List<SessionInfo>>(StringComparer.OrdinalIgnoreCase);
+
+                int maxSessionsToProcess = Math.Min(sessions.Count, 20);
 
                 for (int i = 0; i < maxSessionsToProcess; i++)
                 {
@@ -479,59 +260,21 @@ namespace DeejNG.Services
                         currentProcessIds.Add(processId);
 
                         string procName = AudioUtilities.GetProcessNameSafely(processId);
+                        if (string.IsNullOrEmpty(procName)) continue;
 
-                        if (string.IsNullOrEmpty(procName))
+                        // Group sessions by app name
+                        if (!sessionsByApp.ContainsKey(procName))
                         {
-                            continue;
+                            sessionsByApp[procName] = new List<SessionInfo>();
                         }
 
-                        processedSessions.Add(procName);
-
-                        lock (_cacheLock)
+                        sessionsByApp[procName].Add(new SessionInfo
                         {
-                            // Limit session cache size
-                            if (_sessionCache.Count >= MAX_SESSION_CACHE_SIZE)
-                            {
-                                // Remove oldest entries
-                                var oldestKey = _sessionCache
-                                    .OrderBy(kvp => kvp.Value.LastSeen)
-                                    .First().Key;
-                                _sessionCache.Remove(oldestKey);
-                                _sessionAccessTimes.Remove(oldestKey);
-                            }
-
-                            // CRITICAL FIX: Check if we have a cached session for this process name
-                            // but with a different PID (indicating app restart)
-                            if (_sessionCache.TryGetValue(procName, out var existing))
-                            {
-                                if (existing.ProcessId != processId)
-                                {
-                                    // Process restarted with new PID - replace the cached session
-                                    Debug.WriteLine($"[AudioService] Process {procName} restarted: PID {existing.ProcessId} -> {processId}");
-                                    _sessionCache[procName] = new SessionInfo
-                                    {
-                                        Session = session,
-                                        ProcessName = procName,
-                                        ProcessId = processId,
-                                        LastSeen = currentTime
-                                    };
-                                }
-                                else
-                                {
-                                    existing.LastSeen = currentTime;
-                                }
-                            }
-                            else
-                            {
-                                _sessionCache[procName] = new SessionInfo
-                                {
-                                    Session = session,
-                                    ProcessName = procName,
-                                    ProcessId = processId,
-                                    LastSeen = currentTime
-                                };
-                            }
-                        }
+                            Session = session,
+                            ProcessName = procName,
+                            ProcessId = processId,
+                            LastSeen = currentTime
+                        });
                     }
                     catch (Exception ex)
                     {
@@ -539,16 +282,44 @@ namespace DeejNG.Services
                     }
                 }
 
-                // Remove stale entries more aggressively and invalidate sessions for dead processes
                 lock (_cacheLock)
                 {
-                    var staleThreshold = currentTime.AddMinutes(-2); // Reduce from default to 2 minutes
+                    // Clean up cache size before adding new entries
+                    if (_sessionCache.Count >= MAX_SESSION_CACHE_SIZE)
+                    {
+                        var oldestKeys = _sessionCache
+                            .OrderBy(kvp => _sessionAccessTimes.TryGetValue(kvp.Key, out var time) ? time : DateTime.MinValue)
+                            .Take(_sessionCache.Count - (MAX_SESSION_CACHE_SIZE / 2))
+                            .Select(kvp => kvp.Key)
+                            .ToList();
+
+                        foreach (var key in oldestKeys)
+                        {
+                            _sessionCache.Remove(key);
+                            _sessionAccessTimes.Remove(key);
+                        }
+                    }
+
+                    // Update cache with grouped sessions
+                    foreach (var kvp in sessionsByApp)
+                    {
+                        _sessionCache[kvp.Key] = kvp.Value;
+                        if (!_sessionAccessTimes.ContainsKey(kvp.Key))
+                        {
+                            _sessionAccessTimes[kvp.Key] = currentTime;
+                        }
+                    }
+
+                    // Remove stale entries
+                    var staleThreshold = currentTime.AddMinutes(-2);
                     var toRemove = new List<string>();
 
                     foreach (var kvp in _sessionCache)
                     {
-                        // Remove if too old OR if the process ID is no longer active
-                        if (kvp.Value.LastSeen < staleThreshold || !currentProcessIds.Contains(kvp.Value.ProcessId))
+                        bool isStale = _sessionAccessTimes.TryGetValue(kvp.Key, out var lastAccess) && lastAccess < staleThreshold;
+                        bool hasDeadProcess = kvp.Value.All(si => !currentProcessIds.Contains(si.ProcessId));
+
+                        if (isStale || hasDeadProcess)
                         {
                             toRemove.Add(kvp.Key);
                         }
@@ -562,17 +333,124 @@ namespace DeejNG.Services
 
                     if (toRemove.Count > 0)
                     {
-                        Debug.WriteLine($"[AudioService] Removed {toRemove.Count} stale sessions from cache");
+                        Debug.WriteLine($"[AudioService] Removed {toRemove.Count} stale session groups from cache");
                     }
                 }
 
                 _lastRefresh = currentTime;
+                Debug.WriteLine($"[AudioService] Cache refreshed: {sessionsByApp.Sum(kvp => kvp.Value.Count)} sessions in {sessionsByApp.Count} apps");
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"[AudioService] Failed to refresh session cache: {ex.Message}");
             }
         }
+
+        // Keep all other methods unchanged...
+        public void ApplyMuteStateToMultipleTargets(List<string> targets, bool isMuted)
+        {
+            if (targets == null || !targets.Any()) return;
+            foreach (var target in targets)
+            {
+                ApplyMuteStateToTarget(target, isMuted);
+            }
+        }
+
+        public void ApplyVolumeToUnmappedApplications(float level, bool isMuted, HashSet<string> mappedApplications)
+        {
+            level = Math.Clamp(level, 0.0f, 1.0f);
+
+            var now = DateTime.Now;
+            var timeSinceLastCall = (now - _lastUnmappedVolumeCall).TotalMilliseconds;
+            var volumeChanged = Math.Abs(_lastUnmappedVolume - level) > 0.05f;
+            var muteChanged = _lastUnmappedMuted != isMuted;
+            var appsChanged = !_lastMappedApps.SetEquals(mappedApplications);
+
+            if (timeSinceLastCall < 100 && !volumeChanged && !muteChanged && !appsChanged)
+            {
+                return;
+            }
+
+            _lastUnmappedVolumeCall = now;
+            _lastUnmappedVolume = level;
+            _lastUnmappedMuted = isMuted;
+            _lastMappedApps = new HashSet<string>(mappedApplications);
+
+            try
+            {
+                var device = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var sessions = device.AudioSessionManager.Sessions;
+
+                int processedCount = 0;
+
+                for (int i = 0; i < sessions.Count; i++)
+                {
+                    try
+                    {
+                        var session = sessions[i];
+                        if (session == null) continue;
+
+                        int processId = (int)session.GetProcessID;
+                        if (_systemProcessIds.Contains(processId) || processId < 100) continue;
+
+                        string processName = AudioUtilities.GetProcessNameSafely(processId);
+                        if (string.IsNullOrEmpty(processName) || mappedApplications.Contains(processName)) continue;
+
+                        session.SimpleAudioVolume.Mute = isMuted;
+                        if (!isMuted)
+                        {
+                            session.SimpleAudioVolume.Volume = level;
+                        }
+                        processedCount++;
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"[Unmapped] Failed to apply volume: {ex.GetType().Name}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Unmapped] Failed to apply volume: {ex.GetType().Name}");
+            }
+        }
+
+        public void ApplyMuteStateToUnmappedApplications(bool isMuted, HashSet<string> mappedApplications)
+        {
+            try
+            {
+                var device = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var sessions = device.AudioSessionManager.Sessions;
+
+                int processedCount = 0;
+
+                for (int i = 0; i < sessions.Count; i++)
+                {
+                    try
+                    {
+                        var session = sessions[i];
+                        if (session == null) continue;
+
+                        int processId = (int)session.GetProcessID;
+                        if (_systemProcessIds.Contains(processId) || processId < 100) continue;
+
+                        string processName = AudioUtilities.GetProcessNameSafely(processId);
+                        if (string.IsNullOrEmpty(processName) || mappedApplications.Contains(processName)) continue;
+
+                        session.SimpleAudioVolume.Mute = isMuted;
+                        processedCount++;
+                    }
+                    catch { }
+                }
+
+                Debug.WriteLine($"[Unmapped] Mute {isMuted} applied to {processedCount} apps");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Unmapped] Failed to mute unmapped applications: {ex.GetType().Name}");
+            }
+        }
+
         public void ForceCleanup()
         {
             try
@@ -581,24 +459,22 @@ namespace DeejNG.Services
 
                 lock (_cacheLock)
                 {
-                    // Clear session cache if it's too large
                     if (_sessionCache.Count > 10)
                     {
                         var keysToKeep = _sessionCache
-                            .OrderByDescending(kvp => kvp.Value.LastSeen)
+                            .OrderByDescending(kvp => _sessionAccessTimes.TryGetValue(kvp.Key, out var time) ? time : DateTime.MinValue)
                             .Take(5)
                             .Select(kvp => kvp.Key)
                             .ToList();
 
-                        // Create temporary dictionaries to hold the data we want to keep
-                        var sessionsToKeep = new Dictionary<string, SessionInfo>(StringComparer.OrdinalIgnoreCase);
+                        var sessionsToKeep = new Dictionary<string, List<SessionInfo>>(StringComparer.OrdinalIgnoreCase);
                         var accessTimesToKeep = new Dictionary<string, DateTime>();
 
                         foreach (var key in keysToKeep)
                         {
-                            if (_sessionCache.TryGetValue(key, out var sessionInfo))
+                            if (_sessionCache.TryGetValue(key, out var sessionInfos))
                             {
-                                sessionsToKeep[key] = sessionInfo;
+                                sessionsToKeep[key] = sessionInfos;
                                 if (_sessionAccessTimes.TryGetValue(key, out var accessTime))
                                 {
                                     accessTimesToKeep[key] = accessTime;
@@ -606,7 +482,6 @@ namespace DeejNG.Services
                             }
                         }
 
-                        // Clear the readonly dictionaries and repopulate them
                         _sessionCache.Clear();
                         _sessionAccessTimes.Clear();
 
@@ -620,13 +495,11 @@ namespace DeejNG.Services
                             _sessionAccessTimes[kvp.Key] = kvp.Value;
                         }
 
-                        Debug.WriteLine($"[AudioService] Session cache reduced to {_sessionCache.Count} entries");
+                        Debug.WriteLine($"[AudioService] Session cache reduced to {_sessionCache.Count} apps");
                     }
                 }
 
-                // Force process cache cleanup via centralized utility
                 AudioUtilities.ForceCleanup();
-
                 Debug.WriteLine("[AudioService] Force cleanup completed");
             }
             catch (Exception ex)

--- a/Dialogs/SessionPickerDialog.xaml.cs
+++ b/Dialogs/SessionPickerDialog.xaml.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Windows;
 using NAudio.CoreAudioApi;
+using DeejNG.Classes; // Add this for AudioUtilities
 
 namespace DeejNG.Dialogs
 {
@@ -16,56 +17,81 @@ namespace DeejNG.Dialogs
         {
             var sessionList = new List<SessionInfo>
             {
-                new SessionInfo { Id = "system", FriendlyName = "System" }, // Always include system
-                new SessionInfo { Id = "unmapped", FriendlyName = "Unmapped Applications" } // Add unmapped option
+                new SessionInfo { Id = "system", FriendlyName = "System" },
+                new SessionInfo { Id = "unmapped", FriendlyName = "Unmapped Applications" }
             };
 
-            var enumerator = new MMDeviceEnumerator();
-            var device = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-            var sessions = device.AudioSessionManager.Sessions;
-
-            var seenFriendlyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            try
             {
-                "system",
-                "unmapped" // Don't duplicate these
-            };
+                var enumerator = new MMDeviceEnumerator();
+                var device = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var sessions = device.AudioSessionManager.Sessions;
 
-            foreach (var used in alreadyUsed)
-            {
-                if (!string.Equals(used, current, StringComparison.OrdinalIgnoreCase))
-                    seenFriendlyNames.Add(used);
-            }
+                var seenFriendlyNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "system",
+                    "unmapped"
+                };
 
-            for (int i = 0; i < sessions.Count; i++)
-            {
-                var session = sessions[i];
-                var session2 = session as AudioSessionControl;
-                string id = session.GetSessionIdentifier ?? "(No ID)";
-                string friendlyName = "(Unknown)";
+                // Add already used apps to seen list (except current)
+                foreach (var used in alreadyUsed)
+                {
+                    if (!string.Equals(used, current, StringComparison.OrdinalIgnoreCase))
+                        seenFriendlyNames.Add(used);
+                }
 
-                if (session2 != null)
+                for (int i = 0; i < sessions.Count; i++)
                 {
                     try
                     {
-                        int processId = (int)session2.GetProcessID;
-                        var process = Process.GetProcessById(processId);
-                        friendlyName = Path.GetFileNameWithoutExtension(process.MainModule.FileName);
+                        var session = sessions[i];
+                        if (session == null) continue;
+
+                        // 🔥 FIX: Use safe process name retrieval
+                        int processId;
+                        try
+                        {
+                            processId = (int)session.GetProcessID;
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine($"[SessionPicker] Failed to get process ID for session {i}: {ex.Message}");
+                            continue;
+                        }
+
+                        // 🚀 USE EXISTING SAFE METHOD instead of direct Process access
+                        string friendlyName = AudioUtilities.GetProcessNameSafely(processId);
+
+                        if (string.IsNullOrEmpty(friendlyName))
+                        {
+                            Debug.WriteLine($"[SessionPicker] Could not get process name for PID {processId}");
+                            continue;
+                        }
+
+                        // Only add if we haven't seen this app name before
+                        if (!seenFriendlyNames.Contains(friendlyName))
+                        {
+                            sessionList.Add(new SessionInfo
+                            {
+                                Id = session.GetSessionIdentifier ?? $"pid_{processId}",
+                                FriendlyName = friendlyName
+                            });
+                            seenFriendlyNames.Add(friendlyName);
+                            Debug.WriteLine($"[SessionPicker] Added session: {friendlyName} (PID: {processId})");
+                        }
                     }
                     catch (Exception ex)
                     {
-                        //Debug.WriteLine($"Failed to get process name: {ex.Message}");
+                        Debug.WriteLine($"[SessionPicker] Error processing session {i}: {ex.Message}");
+                        continue;
                     }
                 }
 
-                if (!seenFriendlyNames.Contains(friendlyName))
-                {
-                    sessionList.Add(new SessionInfo
-                    {
-                        Id = id,
-                        FriendlyName = friendlyName
-                    });
-                    seenFriendlyNames.Add(friendlyName);
-                }
+                Debug.WriteLine($"[SessionPicker] Found {sessionList.Count} total sessions ({sessionList.Count - 2} apps)");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SessionPicker] Failed to enumerate audio sessions: {ex.Message}");
             }
 
             return sessionList;
@@ -103,21 +129,43 @@ namespace DeejNG.Dialogs
         public SessionPickerDialog(bool isInputMode)
         {
             InitializeComponent();
-            LoadSessions(isInputMode); // This calls the bool version - keep as is
+            LoadSessions(isInputMode);
         }
 
         public SessionPickerDialog(string current)
         {
             InitializeComponent();
 
-            var allTargets = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault()?.GetCurrentTargets() ?? new List<string>();
-            var sessions = AudioSessionManagerHelper.GetSessionNames(allTargets, current);
+            try
+            {
+                var allTargets = Application.Current.Windows.OfType<MainWindow>().FirstOrDefault()?.GetCurrentTargets() ?? new List<string>();
+                var sessions = AudioSessionManagerHelper.GetSessionNames(allTargets, current);
 
-            SessionComboBox.ItemsSource = sessions;
-            SessionComboBox.DisplayMemberPath = "FriendlyName";
-            SessionComboBox.SelectedValuePath = "Id";
+                SessionComboBox.ItemsSource = sessions;
+                SessionComboBox.DisplayMemberPath = "FriendlyName";
+                SessionComboBox.SelectedValuePath = "Id";
 
-            SessionComboBox.SelectedValue = current;
+                // Try to select the current session
+                var currentSession = sessions.FirstOrDefault(s =>
+                    string.Equals(s.FriendlyName, current, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(s.Id, current, StringComparison.OrdinalIgnoreCase));
+
+                if (currentSession != null)
+                {
+                    SessionComboBox.SelectedItem = currentSession;
+                    Debug.WriteLine($"[SessionPicker] Selected current session: {current}");
+                }
+                else
+                {
+                    Debug.WriteLine($"[SessionPicker] Could not find current session: {current}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SessionPicker] Error in constructor: {ex.Message}");
+                MessageBox.Show($"Error loading audio sessions: {ex.Message}", "Session Picker Error",
+                              MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
         }
 
         #endregion Public Constructors
@@ -132,81 +180,117 @@ namespace DeejNG.Dialogs
 
         private void Ok_Click(object sender, RoutedEventArgs e)
         {
-            if (SessionComboBox.SelectedValue is string selectedId)
-                SelectedSession = selectedId;
-            else
-                SelectedSession = SessionComboBox.Text;
+            try
+            {
+                if (SessionComboBox.SelectedItem is AudioSessionManagerHelper.SessionInfo selectedSession)
+                {
+                    SelectedSession = selectedSession.FriendlyName; // Use FriendlyName for consistency
+                    Debug.WriteLine($"[SessionPicker] Selected: {SelectedSession}");
+                }
+                else if (!string.IsNullOrWhiteSpace(SessionComboBox.Text))
+                {
+                    SelectedSession = SessionComboBox.Text.Trim();
+                    Debug.WriteLine($"[SessionPicker] Manual entry: {SelectedSession}");
+                }
+                else
+                {
+                    Debug.WriteLine("[SessionPicker] No selection made");
+                    return;
+                }
 
-            DialogResult = true;
-            Close();
+                DialogResult = true;
+                Close();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SessionPicker] Error in Ok_Click: {ex.Message}");
+                MessageBox.Show($"Error selecting session: {ex.Message}", "Selection Error",
+                              MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
         }
 
-        // Keep the original LoadSessions method for input mode - DON'T change this one
+        // Keep the original LoadSessions method for input mode compatibility
         private void LoadSessions(bool isInputMode)
         {
-            var items = new List<KeyValuePair<string, string>>();
-
-            if (isInputMode)
+            try
             {
-                // Always include "system" for microphone input control fallback (optional)
-                items.Add(new("System", "system"));
+                var items = new List<KeyValuePair<string, string>>();
 
-                var devices = new MMDeviceEnumerator()
-                    .EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
-
-                foreach (var device in devices)
+                if (isInputMode)
                 {
-                    string name = device.FriendlyName;
-                    items.Add(new(name, name));
-                }
-            }
-            else
-            {
-                // Always include system
-                items.Add(new("System", "system"));
+                    items.Add(new("System", "system"));
 
-                // Add Unmapped Applications option for output mode
-                items.Add(new("Unmapped Applications", "unmapped"));
+                    var devices = new MMDeviceEnumerator()
+                        .EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
 
-                var sessions = new MMDeviceEnumerator()
-                    .GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia)
-                    .AudioSessionManager.Sessions;
-
-                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                for (int i = 0; i < sessions.Count; i++)
-                {
-                    var session = sessions[i];
-                    try
+                    foreach (var device in devices)
                     {
-                        int pid = (int)session.GetProcessID;
+                        string name = device.FriendlyName;
+                        items.Add(new(name, name));
+                    }
+                }
+                else
+                {
+                    items.Add(new("System", "system"));
+                    items.Add(new("Unmapped Applications", "unmapped"));
 
-                        string procName;
+                    var sessions = new MMDeviceEnumerator()
+                        .GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia)
+                        .AudioSessionManager.Sessions;
+
+                    var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                    for (int i = 0; i < sessions.Count; i++)
+                    {
                         try
                         {
-                            procName = Process.GetProcessById(pid).ProcessName;
-                        }
-                        catch
-                        {
-                            procName = "unknown";
-                        }
+                            var session = sessions[i];
+                            if (session == null) continue;
 
-                        if (!seen.Contains(procName))
+                            int processId;
+                            try
+                            {
+                                processId = (int)session.GetProcessID;
+                            }
+                            catch
+                            {
+                                continue;
+                            }
+
+                            // 🔥 FIX: Use safe process name retrieval here too
+                            string procName = AudioUtilities.GetProcessNameSafely(processId);
+
+                            if (string.IsNullOrEmpty(procName))
+                            {
+                                procName = $"unknown_{processId}";
+                            }
+
+                            if (!seen.Contains(procName))
+                            {
+                                items.Add(new(procName, procName.ToLowerInvariant()));
+                                seen.Add(procName);
+                            }
+                        }
+                        catch (Exception ex)
                         {
-                            items.Add(new($"{procName}", procName.ToLowerInvariant()));
-                            seen.Add(procName);
+                            Debug.WriteLine($"[SessionPicker] Error processing session {i} in LoadSessions: {ex.Message}");
                         }
                     }
-                    catch { }
                 }
+
+                SessionComboBox.ItemsSource = items;
+                SessionComboBox.DisplayMemberPath = "Key";
+                SessionComboBox.SelectedValuePath = "Value";
+
+                if (items.Count > 0)
+                    SessionComboBox.SelectedIndex = 0;
             }
-
-            SessionComboBox.ItemsSource = items;
-            SessionComboBox.DisplayMemberPath = "Key";   // what the user sees
-            SessionComboBox.SelectedValuePath = "Value"; // what we use internally
-
-            if (items.Count > 0)
-                SessionComboBox.SelectedIndex = 0;
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SessionPicker] Error in LoadSessions: {ex.Message}");
+                MessageBox.Show($"Error loading sessions: {ex.Message}", "Load Error",
+                              MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
         }
 
         #endregion Private Methods


### PR DESCRIPTION
Updated AudioService to support caching multiple audio sessions per application by changing the session cache structure to a dictionary of lists. Improved methods for muting and volume control to handle multiple sessions, and enhanced the RefreshSessionCache method to group sessions by process name. Added debugging features to log session information and updated the SessionPickerDialog to reflect these changes, improving overall functionality and performance of the audio session management system.