### PR TITLE
Load settings from file before setting PortName

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -95,6 +95,9 @@ namespace DeejNG
 
             _audioService = new AudioService();
 
+            // Load settings but don't auto-connect to serial port yet
+            LoadSettingsWithoutSerialConnection();
+
             // Load the saved port name from settings BEFORE populating ports
             LoadSavedPortName();
 
@@ -158,9 +161,6 @@ namespace DeejNG
             CreateNotifyIconContextMenu();
             IconHandler.AddIconToRemovePrograms("DeejNG");
             SetDisplayIcon();
-
-            // Load settings but don't auto-connect to serial port yet
-            LoadSettingsWithoutSerialConnection();
 
             _isInitializing = false;
             if (_settingsManager.AppSettings.StartMinimized)


### PR DESCRIPTION
Thanks for the awesome app

Just noticed loading the last serial port was not working because the local settings file was loaded after the `PortName` was set.
So I just moved the line loading the settings previous to the line setting the `PortName`.

Does moving the load settings before setting events etc. introduce new issues? It seems to work fine on my pc.