### PR TITLE
Add "Currently Focused Application" option

### DIFF
--- a/Classes/AudioService.cs
+++ b/Classes/AudioService.cs
@@ -306,6 +306,21 @@ namespace DeejNG.Services
 #endif
             }
         }
+        
+        /// <summary>
+        /// Applies the specified volume and mute settings to all audio sessions that are
+        /// mapped to the currently focused window's application.
+        /// </summary>
+        /// <param name="level">Volume level (0.0 to 1.0).</param>
+        /// <param name="isMuted">Whether the session should be muted.</param>
+        public void ApplyVolumeToCurrent(float level, bool isMuted)
+        {
+            var currentTarget = AudioUtilities.GetCurrentFocusTarget();
+            if (currentTarget != "")
+            {
+                ApplyVolumeToTarget(currentTarget, level, isMuted);
+            }
+        }
 
 
         /// <summary>

--- a/Classes/AudioUtilities.cs
+++ b/Classes/AudioUtilities.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using NAudio.CoreAudioApi;
 
 namespace DeejNG.Classes
@@ -29,6 +30,11 @@ namespace DeejNG.Classes
         // Timestamp of the last time the process cache was cleaned
         private static DateTime _lastProcessCacheCleanup = DateTime.MinValue;
 
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
         #endregion Private Fields
 
         #region Public Methods
@@ -99,7 +105,19 @@ namespace DeejNG.Classes
             _processNameCache[processId] = processName;
             return processName;
         }
+        
+        public static string GetCurrentFocusTarget()
+        {
+            IntPtr hWnd = GetForegroundWindow();
+            if (hWnd == IntPtr.Zero)
+            {
+                return "";
+            }
 
+            GetWindowThreadProcessId(hWnd, out uint processId);
+            return GetProcessNameSafely((int)processId);
+        }
+        
         #endregion Public Methods
 
         #region Private Methods

--- a/Dialogs/MultiTargetPickerDialog.xaml.cs
+++ b/Dialogs/MultiTargetPickerDialog.xaml.cs
@@ -179,7 +179,7 @@ namespace DeejNG.Dialogs
 
         /// <summary>
         /// Loads all current audio sessions and wraps them in SelectableSession objects for display.
-        /// Adds special entries for "System" and "Unmapped Applications", and pre-selects any sessions
+        /// Adds special entries for "System", "Unmapped Applications" and "Currently Focused Application" and pre-selects any sessions
         /// that match the provided names.
         /// </summary>
         /// <param name="selectedNames">A set of target names that should be pre-selected in the list.</param>
@@ -206,6 +206,18 @@ namespace DeejNG.Dialogs
                 IsOutputDevice = false
             };
             AvailableSessions.Add(unmappedSession);
+
+
+            // Add "Currently Focused Application" as dynamic currently focused window session
+            var currentSession = new SelectableSession
+            {
+                Id = "current",
+                FriendlyName = "Currently Focused Application",
+                IsSelected = selectedNames.Contains("current"),
+                IsInputDevice = false,
+                IsOutputDevice = false
+            };
+            AvailableSessions.Add(currentSession);
 
             try
             {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -531,7 +531,6 @@ namespace DeejNG
                     }
                     else if (string.Equals(target.Name, "current", StringComparison.OrdinalIgnoreCase))
                     {
-                        
                         _audioService.ApplyVolumeToCurrent(level, ctrl.IsMuted);
                     }
                     else

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -247,6 +247,17 @@ namespace DeejNG
                         return "System";
                     if (name.Equals("unmapped", StringComparison.OrdinalIgnoreCase))
                         return "Unmapped";
+                    if (name.Equals("current", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var label = "Current";
+                        var focusTarget = AudioUtilities.GetCurrentFocusTarget();
+                        if (focusTarget != "")
+                        {
+                            label += $" ({char.ToUpper(focusTarget[0]) + focusTarget[1..].ToLower()})";
+                        }
+
+                        return label;
+                    }
 
                     // For regular app names, return the full name (wrapping will handle display)
                     return char.ToUpper(name[0]) + name.Substring(1).ToLower();
@@ -507,9 +518,21 @@ namespace DeejNG
 
                             var mappedApps = GetAllMappedApplications();
                             mappedApps.Remove("unmapped");
-
+                            if (mappedApps.Remove("current"))
+                            {
+                                var focusTarget = AudioUtilities.GetCurrentFocusTarget();
+                                if (focusTarget != "")
+                                {
+                                    mappedApps.Add(focusTarget);
+                                }
+                            }
                             _audioService.ApplyVolumeToUnmappedApplications(level, ctrl.IsMuted, mappedApps);
                         }
+                    }
+                    else if (string.Equals(target.Name, "current", StringComparison.OrdinalIgnoreCase))
+                    {
+                        
+                        _audioService.ApplyVolumeToCurrent(level, ctrl.IsMuted);
                     }
                     else
                     {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Configurable transpartent overaly with adjustable time out
 - Each slider is mapped to one or more **targets**:
   - System audio
   - Specific applications (by executable name)
+  - Current application (by focused window)
   - Input devices (microphones)
   - Unmapped sessions (everything else)
 - Volume data is received via serial (USB COM port).


### PR DESCRIPTION
I've added a new "Currently Focused Application" option, that checks the focused window and applies volume changes to parent application, similarly to `deej.current` in the original https://github.com/omriharel/deej project.

The current application will have it's name shown in the overlay inside parentheses and will be excluded from the unmapped applications list.