### PR TITLE
Fix serial port/baud rate sync across UI, profiles, connect

### DIFF
--- a/Dialogs/SettingsWindow.xaml.cs
+++ b/Dialogs/SettingsWindow.xaml.cs
@@ -175,6 +175,16 @@ namespace DeejNG.Dialogs
                     int.TryParse(item.Content?.ToString(), out int baud))
                 {
                     _settings.BaudRate = baud;
+
+                    // BUGFIX: Update MainWindow's AppSettings BEFORE triggering connect
+                    // This ensures the connection uses the newly selected baud rate
+                    var currentSettings = _mainWindow.GetCurrentSettings();
+                    currentSettings.BaudRate = baud;
+                    _mainWindow.UpdateOverlaySettings(currentSettings);
+
+#if DEBUG
+                    Debug.WriteLine($"[SettingsWindow] Updated baud rate to {baud} before connect");
+#endif
                 }
 
                 // Forward the click to the main window's connect button

--- a/Services/ProfileManager.cs
+++ b/Services/ProfileManager.cs
@@ -79,6 +79,11 @@ namespace DeejNG.Services
 #if DEBUG
                     Debug.WriteLine($"[Profiles] Loaded {_profileCollection.Profiles.Count} profiles from disk");
                     Debug.WriteLine($"[Profiles] Active profile: {_profileCollection.ActiveProfileName}");
+                    var activeProfile = _profileCollection.GetActiveProfile();
+                    if (activeProfile != null)
+                    {
+                        Debug.WriteLine($"[Profiles] Active profile settings - PortName: '{activeProfile.Settings?.PortName}', BaudRate: {activeProfile.Settings?.BaudRate}");
+                    }
 #endif
                 }
                 else
@@ -141,7 +146,8 @@ namespace DeejNG.Services
 
 #if DEBUG
                     Debug.WriteLine("[Profiles] Migrated legacy settings to 'Default' profile");
-                    Debug.WriteLine($"[Profiles]   - Port: {legacySettings.PortName}");
+                    Debug.WriteLine($"[Profiles]   - Port: '{legacySettings.PortName}'");
+                    Debug.WriteLine($"[Profiles]   - BaudRate: {legacySettings.BaudRate}");
                     Debug.WriteLine($"[Profiles]   - Sliders: {legacySettings.SliderTargets?.Count ?? 0}");
 #endif
 


### PR DESCRIPTION
Ensure baud rate and port name are consistently updated, saved, and restored between the UI, profile system, and connection logic. Fixes issues where user selections could be lost when switching profiles, saving/loading settings, or connecting/disconnecting. Adds debug output for easier troubleshooting and keeps settings.json and profiles.json in sync.
fixes #96 