### PR TITLE
Add exponential volume curve

### DIFF
--- a/Classes/AppSettings.cs
+++ b/Classes/AppSettings.cs
@@ -71,6 +71,16 @@ namespace DeejNG.Classes
         public bool StartOnBoot { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the application should use an exponential volume curve.
+        /// </summary>
+        public bool UseExponentialVolume { get; set; }
+
+        /// <summary>
+        /// The factor to use for the exponential volume curve. A higher factor makes the curve more agressive.
+        /// </summary>
+        public float ExponentialVolumeFactor { get; set; } = 2;
+
+        /// <summary>
         /// Gets or sets a value indicating whether VU meters are enabled.
         /// </summary>
         public bool VuMeters { get; set; } = true;

--- a/Dialogs/SettingsWindow.xaml
+++ b/Dialogs/SettingsWindow.xaml
@@ -61,7 +61,7 @@
 
                 <StackPanel Grid.Row="0" Grid.Column="0">
                     <TextBlock Text="General" Style="{StaticResource TitleTextBlock}" FontSize="18" Margin="0,0,0,16"/>
-                    <Border Style="{StaticResource Card}" Padding="20" Margin="0,0,0,20" Height="207">
+                    <Border Style="{StaticResource Card}" Padding="20" Margin="0,0,0,20" Height="227">
                         <StackPanel>
                             <CheckBox x:Name="SettingInvertSliders" Content="Invert Sliders" Margin="0,0,0,12"
                                       Foreground="{DynamicResource TextPrimaryBrush}"/>
@@ -71,8 +71,21 @@
                                       Foreground="{DynamicResource TextPrimaryBrush}"/>
                             <CheckBox x:Name="SettingStartMinimized" Content="Start minimized" Margin="0,0,0,12"
                                       Foreground="{DynamicResource TextPrimaryBrush}"/>
-                            <CheckBox x:Name="SettingDisableSmoothing" Content="Disable Smoothing"
+                            <CheckBox x:Name="SettingDisableSmoothing" Content="Disable Smoothing" Margin="0,0,0,12"
                                       Foreground="{DynamicResource TextPrimaryBrush}"/>
+                            <CheckBox x:Name="SettingUseExponentialVolume" Content="Use Exponential Volume" Margin="0,0,0,12"
+                                      Foreground="{DynamicResource TextPrimaryBrush}"/>
+                            <Grid Margin="0,0,0,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="Exp. Volume Factor" Style="{StaticResource LabelTextBlock}" VerticalAlignment="Center" Width="130"/>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                    <Slider x:Name="ExponentialVolumeFactorSlider" Minimum="1.5" Maximum="10.0" Width="180" TickFrequency="0.1" IsSnapToTickEnabled="True" VerticalAlignment="Center"/>
+                                    <TextBlock Text="{Binding ElementName=ExponentialVolumeFactorSlider, Path=Value, StringFormat={}{0:F1}}" Margin="10,0,0,0" VerticalAlignment="Center" Style="{StaticResource SubtitleTextBlock}"/>
+                                </StackPanel>
+                            </Grid>
                         </StackPanel>
                     </Border>
 

--- a/Dialogs/SettingsWindow.xaml.cs
+++ b/Dialogs/SettingsWindow.xaml.cs
@@ -57,6 +57,7 @@ namespace DeejNG.Dialogs
             OpacitySlider.Value = _settings.OverlayOpacity;
             AutoCloseCheckBox.IsChecked = _settings.OverlayTimeoutSeconds > 0;
             TimeoutSlider.Value = _settings.OverlayTimeoutSeconds;
+            ExponentialVolumeFactorSlider.Value = _settings.ExponentialVolumeFactor;
 
             SetTextColorSelection(_settings.OverlayTextColor); // Set ComboBox for text color
 
@@ -68,6 +69,8 @@ namespace DeejNG.Dialogs
                 SettingStartOnBoot.IsChecked = _mainWindow.StartOnBootCheckBox.IsChecked;
                 SettingStartMinimized.IsChecked = _mainWindow.StartMinimizedCheckBox.IsChecked;
                 SettingDisableSmoothing.IsChecked = _mainWindow.DisableSmoothingCheckBox.IsChecked;
+                SettingUseExponentialVolume.IsChecked = _mainWindow.UseExponentialVolumeCheckBox.IsChecked;
+                ExponentialVolumeFactorSlider.Value = _mainWindow.ExponentialVolumeFactorSlider.Value;
 
                 // Initialize COM port controls from main window
                 SettingComPortSelector.ItemsSource = _mainWindow.ComPortSelector.ItemsSource;
@@ -98,6 +101,9 @@ namespace DeejNG.Dialogs
             SettingStartMinimized.Unchecked += ForwardGeneralCheckbox;
             SettingDisableSmoothing.Checked += ForwardGeneralCheckbox;
             SettingDisableSmoothing.Unchecked += ForwardGeneralCheckbox;
+            SettingUseExponentialVolume.Checked += ForwardGeneralCheckbox;
+            SettingUseExponentialVolume.Unchecked += ForwardGeneralCheckbox;
+            ExponentialVolumeFactorSlider.ValueChanged += ForwardGeneralSlider;
 
             // Wire COM port selection changes
             SettingComPortSelector.SelectionChanged += SettingComPortSelector_SelectionChanged;
@@ -141,6 +147,16 @@ namespace DeejNG.Dialogs
                 _mainWindow.StartMinimizedCheckBox.IsChecked = SettingStartMinimized.IsChecked;
             else if (sender == SettingDisableSmoothing)
                 _mainWindow.DisableSmoothingCheckBox.IsChecked = SettingDisableSmoothing.IsChecked;
+            else if (sender == SettingUseExponentialVolume)
+                _mainWindow.UseExponentialVolumeCheckBox.IsChecked = SettingUseExponentialVolume.IsChecked;
+        }
+
+        private void ForwardGeneralSlider(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (_mainWindow == null) return;
+
+            if (sender == ExponentialVolumeFactorSlider)
+                _mainWindow.ExponentialVolumeFactorSlider.Value = ExponentialVolumeFactorSlider.Value;
         }
 
         private void SettingComPortSelector_DropDownOpened(object sender, EventArgs e)

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -180,6 +180,14 @@
                               Checked="StartOnBootCheckBox_Checked"
                               Unchecked="StartOnBootCheckBox_Unchecked"/>
 
+                <ToggleButton x:Name="UseExponentialVolumeCheckBox"
+                              Content="Use exponential volume curve"
+                              Style="{StaticResource SwitchToggleStyle}"
+                              Checked="UseExponentialVolumeCheckBox_Checked"
+                              Unchecked="UseExponentialVolumeCheckBox_Unchecked"/>
+
+                <Slider x:Name="ExponentialVolumeFactorSlider" ValueChanged="ExponentialVolumeFactorSlider_Changed"/>
+
                 <ToggleButton x:Name="StartMinimizedCheckBox"
                               Content="Start minimized"
                               Style="{StaticResource SwitchToggleStyle}"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -55,6 +55,8 @@ namespace DeejNG
         private MMDevice _cachedAudioDevice;
         private SessionCollection _cachedSessionsForMeters;
         private bool _disableSmoothing = false;
+        private bool _useExponentialVolume = false;
+        private float _exponentialVolumeFactor = 2f;
         private int _expectedSliderCount = -1;
         private bool _hasLoadedInitialSettings = false;
         private bool _hasSyncedMuteStates = false;
@@ -1125,6 +1127,24 @@ namespace DeejNG
             SaveSettings();
         }
 
+        private void UseExponentialVolumeCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            _useExponentialVolume = true;
+            SaveSettings();
+        }
+
+        private void UseExponentialVolumeCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            _useExponentialVolume = false;
+            SaveSettings();
+        }
+
+        private void ExponentialVolumeFactorSlider_Changed(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            _exponentialVolumeFactor = (float)e.NewValue;
+            SaveSettings();
+        }
+
         private async void ExitMenuItem_Click(object sender, RoutedEventArgs e)
         {
             Application.Current.Shutdown();
@@ -1352,6 +1372,9 @@ namespace DeejNG
                             level = Math.Clamp(level / 1023f, 0f, 1f);
                             if (InvertSliderCheckBox.IsChecked ?? false)
                                 level = 1f - level;
+
+                            if (_useExponentialVolume)
+                                level = (MathF.Pow(_exponentialVolumeFactor, level) / (_exponentialVolumeFactor - 1)) - (1 / (_exponentialVolumeFactor - 1));
 
                             float currentVolume = ctrl.CurrentVolume;
                             if (Math.Abs(currentVolume - level) < 0.01f) continue;
@@ -1825,6 +1848,9 @@ namespace DeejNG
 
                 SetMeterVisibilityForAll(settings.VuMeters);
                 DisableSmoothingCheckBox.IsChecked = settings.DisableSmoothing;
+                UseExponentialVolumeCheckBox.IsChecked = settings.UseExponentialVolume;
+
+                ExponentialVolumeFactorSlider.Value = settings.ExponentialVolumeFactor;
 
                 _settingsManager.ValidateOverlayPosition();
 
@@ -2009,6 +2035,8 @@ namespace DeejNG
                     StartOnBootCheckBox.IsChecked ?? false,
                     StartMinimizedCheckBox.IsChecked ?? false,
                     DisableSmoothingCheckBox.IsChecked ?? false,
+                    UseExponentialVolumeCheckBox.IsChecked ?? false,
+                    (float)ExponentialVolumeFactorSlider.Value,
                     // BUGFIX: Use baud rate from AppSettings instead of CurrentBaudRate
                     // This ensures user's baud rate selection is preserved even if not connected
                     _settingsManager.AppSettings.BaudRate > 0 ? _settingsManager.AppSettings.BaudRate : _serialManager.CurrentBaudRate

--- a/Services/AppSettingsManager.cs
+++ b/Services/AppSettingsManager.cs
@@ -459,6 +459,8 @@ namespace DeejNG.Services
             bool startOnBoot,
             bool startMinimized,
             bool disableSmoothing,
+            bool exponentialVolume,
+            float exponentialVolumeFactor,
             int baudRate)
         {
             return new AppSettings
@@ -471,6 +473,8 @@ namespace DeejNG.Services
                 StartOnBoot = startOnBoot,
                 StartMinimized = startMinimized,
                 DisableSmoothing = disableSmoothing,
+                UseExponentialVolume = exponentialVolume,
+                ExponentialVolumeFactor = exponentialVolumeFactor,
                 BaudRate = baudRate,
 
                 // Preserve overlay settings from current settings


### PR DESCRIPTION
This PR adds the option to add an exponential curve to the volume sliders, allowing more fine grained control in lower volumes.

I added it since I was personally not entirely happy with the way Windows handles the volume curving. Based on that, I found this discussion on it:
https://news.ycombinator.com/item?id=27828587

After having tried it briefly, Volume2 that was mentioned, with exponential mode enabled, does not handle nicely with setting the volumes to specific percentages, and thus doesn't give good results in combination with DeejNG.

Because of this issue, I've decided to add exponential curving to the volume function inside DeejNG, and am quite happy with the result.

There is now a toggle to enable or disable the exponential curve logic, and the option to change the factor for more agressive curving. Typically a factor of 2.0 seems to be good.